### PR TITLE
[Player] Tweak the way we add new genes

### DIFF
--- a/fr/tvbarthel/musictower/ai/LocalBot.py
+++ b/fr/tvbarthel/musictower/ai/LocalBot.py
@@ -3,9 +3,10 @@ from Bot import Bot
 
 class LocalBot(Bot):
     DEFAULT_TARGET_DELTAS = [1100, 800, 800, 800, 800, 800, 800, 800, 800, 800, 800, 800, 800,
-                             700, 700, 700, 700, 700, 600, 600, 600, 700, 700, 800, 800, 900]
+                             700, 700, 700, 700, 700, 600, 600, 600, 700, 700, 800, 800, 900,
+                             900, 900, 900, 800, 800, 800, 800, 800, 800, 800, 800, 800, 800]
 
-    DEFAULT_TOTAL_ERROR = 400
+    DEFAULT_TOTAL_ERROR = 800
 
     def __init__(self, target_deltas=DEFAULT_TARGET_DELTAS, total_error=DEFAULT_TOTAL_ERROR):
         Bot.__init__(self)

--- a/fr/tvbarthel/musictower/ai/Player.py
+++ b/fr/tvbarthel/musictower/ai/Player.py
@@ -1,11 +1,11 @@
-from random import choice, random, randint
+from random import choice, random, gauss
 
 
 class Player:
     MUTATION_FACTORS = [-30, -20, -10, 10, 20, 30]
-    NEW_GENE_DEFAULT_OFFSET = 1000
-    NEW_GENE_MIN_VARIATION = -100
-    NEW_GENE_MAX_VARIATION = 100
+    NEW_GENE_DEFAULT_DELTA = 800
+    NEW_GENE_MAX_VARIATION_NARROW = 50
+    NEW_GENE_MAX_VARIATION_BROAD = 500
 
     def __init__(self, dna):
         self.dna = dna
@@ -38,9 +38,9 @@ class Player:
         :return: a newly created player.
         """
         first_parent_dna = self.get_dna()
-        first_parent_score = self.score
+        first_parent_last_meaningful_gene_index = self.score - 1
         second_parent_dna = player.get_dna()
-        second_parent_score = player.score
+        second_parent_last_meaningful_gene_index = player.score - 1
 
         if len(first_parent_dna) is not len(second_parent_dna):
             raise ValueError("Player should have the same dna length")
@@ -50,18 +50,27 @@ class Player:
         parent_pool_dna = [first_parent_dna, second_parent_dna]
 
         for index in range(dna_length):
-            if (index <= first_parent_score) and (index <= second_parent_score):
+            if (index <= first_parent_last_meaningful_gene_index) and \
+                    (index <= second_parent_last_meaningful_gene_index):
                 parent_dna = choice(parent_pool_dna)
-            elif index <= first_parent_score:
+            elif index <= first_parent_last_meaningful_gene_index:
                 parent_dna = first_parent_dna
-            elif index <= second_parent_score:
+            elif index <= second_parent_last_meaningful_gene_index:
                 parent_dna = second_parent_dna
             else:
-                parent_dna = choice(parent_pool_dna)
+                parent_dna = None
 
-            child_reference = child_dna[-1] if child_dna else 0
-            parent_delta = parent_dna[index] - parent_dna[index - 1] if index > 0 else parent_dna[index]
-            child_dna.append(child_reference + parent_delta)
+            if parent_dna:
+                child_reference = child_dna[-1] if child_dna else 0
+                parent_delta = parent_dna[index] - parent_dna[index - 1] if index > 0 else parent_dna[index]
+                gene_value = child_reference + parent_delta
+            else:
+                reference = child_dna[-1] if child_dna else 0
+                last_delta = Player.__get_last_delta(child_dna)
+                # Use a broader window to try to find the new rhythm
+                gene_value = Player.__get_new_gene_value(reference, last_delta, Player.NEW_GENE_MAX_VARIATION_BROAD)
+
+            child_dna.append(gene_value)
 
         return Player(child_dna)
 
@@ -88,16 +97,26 @@ class Player:
         if number_of_genes_to_add <= 0:
             raise ValueError("The number of genes to add must be strictly positive")
 
-        dna_length = len(self.dna)
-        if dna_length >= 2:
-            offset = self.dna[-1] - self.dna[-2]
-        elif dna_length >= 1:
-            offset = self.dna[-1]
-        else:
-            offset = Player.NEW_GENE_DEFAULT_OFFSET
-
+        last_delta = Player.__get_last_delta(self.dna)
         for index in range(number_of_genes_to_add):
             reference = self.dna[-1] if self.dna else 0
-            variation = randint(Player.NEW_GENE_MIN_VARIATION, Player.NEW_GENE_MAX_VARIATION)
-            new_value = max(0, reference + offset + variation)
+            # Use a narrow window: try to stay in rhythm at first
+            new_value = Player.__get_new_gene_value(reference, last_delta, Player.NEW_GENE_MAX_VARIATION_NARROW)
             self.dna.append(new_value)
+
+    @staticmethod
+    def __get_last_delta(dna):
+        dna_length = len(dna)
+        if dna_length >= 2:
+            return dna[-1] - dna[-2]
+        elif dna_length >= 1:
+            return dna[-1]
+        else:
+            return Player.NEW_GENE_DEFAULT_DELTA
+
+    @staticmethod
+    def __get_new_gene_value(previous_gene, previous_delta, max_variation):
+        target_min = max(previous_gene + 200, previous_gene + previous_delta - max_variation)
+        target_max = min(previous_gene + 1400, previous_gene + previous_delta + max_variation)
+        variation = max(0, min(2, 1 + gauss(0, 0.2))) / 2
+        return int(target_min + (target_max - target_min) * variation)


### PR DESCRIPTION
[Player] Tweak the way we add new genes
When adding new genes, we now use a narrow window around
the previous delta. The objective is to stay in rythm.

When no parents have a meaningful gene to give to the child,
we use a broader window around the previous child delta to explore
and find the new rhythm.

This version of player can now adapt itself to rhythm variation.